### PR TITLE
Fix _create_t method for more recent releases of Module::Starter::Simple

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5,5 +5,6 @@ Makefile.PL
 README
 lib/Module/Starter/Smart.pm
 t/00.load.t
+t/02.create_t.t
 t/pod-coverage.t
 t/pod.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -5,6 +5,7 @@ Makefile.PL
 README
 lib/Module/Starter/Smart.pm
 t/00.load.t
+t/01.create_distro.t
 t/02.create_t.t
 t/pod-coverage.t
 t/pod.t

--- a/lib/Module/Starter/Smart.pm
+++ b/lib/Module/Starter/Smart.pm
@@ -170,11 +170,12 @@ sub create_t {
 }
 
 sub _create_t {
-    my $self = shift;
+    my $self     = shift;
+    my $testdir  = @_ == 2 ? 't' : shift;
     my $filename = shift;
-    my $content = shift;
+    my $content  = shift;
 
-    my @dirparts = ( $self->{basedir}, "t" );
+    my @dirparts = ( $self->{basedir}, $testdir );
     my $tdir = File::Spec->catdir( @dirparts );
     if ( not -d $tdir ) {
         local @ARGV = $tdir;
@@ -193,7 +194,7 @@ sub _create_t {
         $self->progress( "Created $fname" );
     }
 
-    return "t/$filename";
+    return File::Spec->catfile( $testdir, $filename );
 }
 
 sub create_Makefile_PL {

--- a/t/02.create_t.t
+++ b/t/02.create_t.t
@@ -1,0 +1,61 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::TempDir::Tiny;
+use File::Spec::Functions qw(catdir catfile);
+use Module::Starter qw(Module::Starter::Smart);
+
+my $content = <<"EOF";
+I think that I shall never see,
+a test as concise as this in ./t!
+EOF
+
+test_old_interface();
+test_new_interface();
+
+done_testing();
+
+sub test_old_interface {
+    my $tempdir  = tempdir();
+    my $tdir     = catdir($tempdir, 't');
+    my $testfile = '01.test.t';
+    my $starter  = Module::Starter::Smart->new();
+    $starter->{basedir} = $tempdir;
+
+    Module::Starter::Smart::_create_t($starter, $testfile, $content);
+
+    file_contains_ok(catfile($tdir, $testfile), $content);
+}
+
+sub test_new_interface {
+    my $tempdir   = tempdir();
+    my $tdir      = catdir($tempdir, 't');
+    my $xtdir     = catdir($tempdir, 'xt');
+    my $testfile1 = '01.test.t';
+    my $testfile2 = '02.test.t';
+    my $starter   = Module::Starter::Smart->new();
+    $starter->{basedir} = $tempdir;
+
+    Module::Starter::Smart::_create_t($starter, 't',  $testfile1, $content);
+    Module::Starter::Smart::_create_t($starter, 'xt', $testfile2, $content);
+
+    file_contains_ok(catfile($tdir,  $testfile1), $content);
+    file_contains_ok(catfile($xtdir, $testfile2), $content);
+}
+
+sub file_contains_ok {
+    my $file = shift;
+    my $expected_content = shift;
+
+    SKIP: {
+        skip "File '$file' does not exist or is unreadable", 1
+            unless ok(-f -r $file, "File '$file' exists and is readable");
+
+        open my $fh, '<', $file or die "Cannot open $file: $!\n";
+        my $real_content = do { local $/; <$fh> };
+        close $fh;
+
+        ok($expected_content eq $real_content, "File '$file' has correct content");
+    }
+}


### PR DESCRIPTION
Fix Module::Starter::Smart's own `_create_t` method to play along nicely with more recent releases (>= 1.70) of Module::Starter::Simple. Also add already existing test for `create_distro` to the `MANIFEST`.

For reference, here are both the old and the new protocol for `_create_t` as defined by Module::Starter::Simple:

```Perl
# old protocol in 1.6.3 and below
my $self = shift;
my $filename = shift;
my $content = shift;

# new protocol in 1.7.0 and above
my $self = shift;
my $directory = shift;  # 't' or 'xt'
my $filename = shift;
my $content = shift;
```

Edit: Added both old and new protocol