### PR TITLE
add license and min perl version and new test

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,9 +7,11 @@ WriteMakefile(
     AUTHOR              => 'Ruey-Cheng Chen <rueycheng@cpan.com>',
     VERSION_FROM        => 'lib/Module/Starter/Smart.pm',
     ABSTRACT_FROM       => 'lib/Module/Starter/Smart.pm',
+    MIN_PERL_VERSION    => 5.6.0,
     PL_FILES            => {},
+    LICENSE             => 'perl',
     BUILD_REQUIRES      => {
-        'ExtUtils::MakeMaker'  => 0,
+        'ExtUtils::MakeMaker'  => 6.48,
         'File::Spec'           => 0,
         'parent'               => 0,
         'Module::Starter'      => 1.58,

--- a/t/03.create_distro_with_build.t
+++ b/t/03.create_distro_with_build.t
@@ -1,0 +1,34 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+use Test::TempDir::Tiny;
+use Module::Starter qw/Module::Starter::Smart/;
+use File::Spec;
+
+my $tempdir = tempdir();
+my $root = File::Spec->catdir($tempdir, 'Foo-Bar');
+
+{
+    local $SIG{__WARN__} = sub {
+        warn $_[0] unless $_[0] =~ /^Added to MANIFEST/;
+    };
+
+    Module::Starter->create_distro(
+        author  => 'me',
+        builder  => 'Module::Build',
+        modules  => ['Foo::Bar'],
+        email    => 'me@there.com',
+        dir      => $root,
+    );
+}
+
+ok(-d $root, 'Module root exists');
+
+my $file = File::Spec->catfile($root, qw(lib Foo Bar.pm));
+ok(-f $file, 'Module file exists');
+
+push @INC, File::Spec->catdir($root, 'lib');
+require_ok('Foo::Bar');


### PR DESCRIPTION
Hi,

I was given your module as part of the PR Pull request challenge.

This adds the license and min perl version to the MakeFile to resolve the 2 'extra issues' cpants warnings (https://cpants.cpanauthors.org/dist/Module-Starter-Smart).

I have also ran test coverage against the repo and found that the 'create_Build_PL' function did not have a test. Therefore I have added a test for this.

Regards
Lisa